### PR TITLE
Run development in docker

### DIFF
--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -it -v $(PWD):/srv/jekyll -p 4000:4000 -p 35729:35729 jekyll/jekyll:3.7.2 jekyll serve --livereload


### PR DESCRIPTION
Added script to start `jekyll serve` in docker. Just run `./run-in-docker.sh` from your command line and of course start docker before.
Livereload is enabled. Do your changes, hit save and it will be live inside the docker container.